### PR TITLE
Fixed deprecation warning

### DIFF
--- a/src/templates/_components/sales.twig
+++ b/src/templates/_components/sales.twig
@@ -92,7 +92,7 @@
                             {{ sale.name }}
                         </td>
                         <td>
-                            {{ sale.edition|ucfirst }}
+                            {{ sale.edition|capitalize }}
                         </td>
                         <td>
                             {{ sale.renewal ? 'Renewal'|t('plugin-sales') : 'Licence'|t('plugin-sales') }}


### PR DESCRIPTION
Fixes the following deprecation warning...

> **Deprecation error:** The |ucfirst filter has been deprecated. Use |capitalize instead.
Called from /vendor/craftcms/cms/src/web/twig/Extension.php:464
>
> craft\web\twig\Extension::ucfirstFilter("standard")
Called from /vendor/putyourlightson/craft-plugin-sales/src/templates/_components/sales.twig:95