### PR TITLE
fix: changed `|ucfirst` to `|capitalize` to stop deprecation warning

### DIFF
--- a/src/templates/_components/sales.twig
+++ b/src/templates/_components/sales.twig
@@ -92,7 +92,7 @@
                             {{ sale.name }}
                         </td>
                         <td>
-                            {{ sale.edition|ucfirst }}
+                            {{ sale.edition|capitalize }}
                         </td>
                         <td>
                             {{ sale.renewal ? 'Renewal'|t('plugin-sales') : 'Licence'|t('plugin-sales') }}


### PR DESCRIPTION
Otherwise Craft shows the following warning:

`The |ucfirst filter has been deprecated. Use |capitalize instead.`